### PR TITLE
Configurable exch rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ forge create --rpc-url $SEPOLIA_RPC --private-key $SEPOLIA_PRIVATE_KEY src/fauce
 Deploy the `ReactiveFaucet` contract to the Reactive Network and assign the `Deployed to` address from the response to `REACTIVE_FAUCET_ADDR`.
 
 ```bash
-forge create --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY src/faucet/ReactiveFaucet.sol:ReactiveFaucet --value 10000ether --constructor-args $REACTIVE_FAUCET_L1_ADDR 5ether 50000
+forge create --legacy --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY src/faucet/ReactiveFaucet.sol:ReactiveFaucet --value 10000ether --constructor-args $REACTIVE_FAUCET_L1_ADDR 5ether 50000
 ```
 
 ### Step 3
@@ -54,17 +54,17 @@ cast send $REACTIVE_FAUCET_L1_ADDR --rpc-url $SEPOLIA_RPC --private-key $SEPOLIA
 To pause the reactive contract:
 
 ```bash
-cast send $REACTIVE_FAUCET_ADDR "pause()" --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY
+cast send --legacy $REACTIVE_FAUCET_ADDR "pause()" --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY
 ```
 
 To resume the reactive contract:
 
 ```bash
-cast send $REACTIVE_FAUCET_ADDR "resume()" --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY
+cast send --legacy $REACTIVE_FAUCET_ADDR "resume()" --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY
 ```
 
 Provide additional funds to the reactive contract if needed:
 
 ```bash
-cast send $REACTIVE_FAUCET_ADDR --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY --value 1000ether
+cast send --legacy $REACTIVE_FAUCET_ADDR --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY --value 1000ether
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ forge create --rpc-url $SEPOLIA_RPC --private-key $SEPOLIA_PRIVATE_KEY src/fauce
 Deploy the `ReactiveFaucet` contract to the Reactive Network and assign the `Deployed to` address from the response to `REACTIVE_FAUCET_ADDR`.
 
 ```bash
-forge create --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY src/faucet/ReactiveFaucet.sol:ReactiveFaucet --value 10ether --constructor-args $REACTIVE_FAUCET_L1_ADDR 1ether
+forge create --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY src/faucet/ReactiveFaucet.sol:ReactiveFaucet --value 10000ether --constructor-args $REACTIVE_FAUCET_L1_ADDR 5ether 50000
 ```
 
 ### Step 3
@@ -66,5 +66,5 @@ cast send $REACTIVE_FAUCET_ADDR "resume()" --rpc-url $REACTIVE_RPC --private-key
 Provide additional funds to the reactive contract if needed:
 
 ```bash
-cast send $REACTIVE_FAUCET_ADDR --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY --value 0.1ether
+cast send $REACTIVE_FAUCET_ADDR --rpc-url $REACTIVE_RPC --private-key $REACTIVE_PRIVATE_KEY --value 1000ether
 ```

--- a/src/faucet/ReactiveFaucet.sol
+++ b/src/faucet/ReactiveFaucet.sol
@@ -75,10 +75,12 @@ contract ReactiveFaucet is AbstractPausableReactive, AbstractCallback {
     // Methods specific to ReactVM contract instance
 
     function react(LogRecord calldata log) external vmOnly {
+        uint256 amount = log.topic_2 / 10;
         bytes memory payload = abi.encodeWithSignature(
             "dispense(address,address,uint256)",
             address(0),
-            address(uint160(log.topic_1))
+            address(uint160(log.topic_1)),
+            amount
         );
         emit Callback(block.chainid, address(this), CALLBACK_GAS_LIMIT, payload);
     }

--- a/src/faucet/ReactiveFaucet.sol
+++ b/src/faucet/ReactiveFaucet.sol
@@ -75,13 +75,10 @@ contract ReactiveFaucet is AbstractPausableReactive, AbstractCallback {
     // Methods specific to ReactVM contract instance
 
     function react(LogRecord calldata log) external vmOnly {
-        uint256 adjustedAmount = (log.topic_2 * exchangeRate) / (10 * EXCHANGE_RATE_FACTOR);
-
         bytes memory payload = abi.encodeWithSignature(
             "dispense(address,address,uint256)",
             address(0),
-            address(uint160(log.topic_1)),
-            adjustedAmount
+            address(uint160(log.topic_1))
         );
         emit Callback(block.chainid, address(this), CALLBACK_GAS_LIMIT, payload);
     }

--- a/src/faucet/ReactiveFaucet.sol
+++ b/src/faucet/ReactiveFaucet.sol
@@ -75,12 +75,11 @@ contract ReactiveFaucet is AbstractPausableReactive, AbstractCallback {
     // Methods specific to ReactVM contract instance
 
     function react(LogRecord calldata log) external vmOnly {
-        uint256 amount = log.topic_2 / 10;
         bytes memory payload = abi.encodeWithSignature(
             "dispense(address,address,uint256)",
             address(0),
             address(uint160(log.topic_1)),
-            amount
+            log.topic_2
         );
         emit Callback(block.chainid, address(this), CALLBACK_GAS_LIMIT, payload);
     }

--- a/src/faucet/ReactiveFaucet.sol
+++ b/src/faucet/ReactiveFaucet.sol
@@ -6,20 +6,20 @@ import '../../lib/reactive-lib/src/abstract-base/AbstractCallback.sol';
 import '../../lib/reactive-lib/src/abstract-base/AbstractPausableReactive.sol';
 
 contract ReactiveFaucet is AbstractPausableReactive, AbstractCallback {
+
     uint256 private constant SEPOLIA_CHAIN_ID = 11155111;
-
     uint256 private constant PAYMENT_REQUEST_TOPIC_0 = 0x8e191feb68ec1876759612d037a111be48d8ec3db7f72e4e7d321c2c8008bd0d;
-
     uint64 private constant CALLBACK_GAS_LIMIT = 1000000;
 
     // State specific to ReactVM contract instance
-
     address private l1;
     uint256 public max_payout;
+    uint256 public exchangeRate;
 
-    constructor(address _l1, uint256 _max_payout) AbstractCallback(address(SERVICE_ADDR)) payable {
-        max_payout = _max_payout;
+    constructor(address _l1, uint256 _max_payout, uint256 _exchangeRate) AbstractCallback(address(SERVICE_ADDR)) payable {
         l1 = _l1;
+        max_payout = _max_payout;
+        exchangeRate = _exchangeRate;
         bytes memory payload = abi.encodeWithSignature(
             "subscribe(uint256,address,uint256,uint256,uint256,uint256)",
             SEPOLIA_CHAIN_ID,
@@ -41,32 +41,26 @@ contract ReactiveFaucet is AbstractPausableReactive, AbstractCallback {
         _;
     }
 
-    function getPausableSubscriptions() override internal view returns (Subscription[] memory) {
-        Subscription[] memory result = new Subscription[](1);
-        result[0] = Subscription(
-            SEPOLIA_CHAIN_ID,
-            l1,
-            PAYMENT_REQUEST_TOPIC_0,
-            REACTIVE_IGNORE,
-            REACTIVE_IGNORE,
-            REACTIVE_IGNORE
-        );
-        return result;
-    }
-
     function dispense(address sender, address payable receiver, uint256 amount) external onlyReactive(sender) {
-        require(amount <= max_payout, 'Max payout exceeded');
-        require(amount <= address(this).balance, 'Not enough funds');
-        receiver.transfer(amount);
+        uint256 adjustedAmount = (amount * exchangeRate) / 1e18; // Apply exchange rate
+        require(adjustedAmount <= max_payout, 'Max payout exceeded');
+        require(adjustedAmount <= address(this).balance, 'Not enough funds');
+        receiver.transfer(adjustedAmount);
     }
 
     function setMaxPayout(uint256 _max_payout) external onlyOwner {
         max_payout = _max_payout;
     }
 
+    function setExchangeRate(uint256 _exchangeRate) external onlyOwner {
+        exchangeRate = _exchangeRate;
+    }
+
     // Methods specific to ReactVM contract instance
 
     function react(LogRecord calldata log) external vmOnly {
+        uint256 adjustedAmount = (log.topic_2 * exchangeRate) / (10 * 1e18);
+
         bytes memory payload = abi.encodeWithSignature(
             "dispense(address,address,uint256)",
             address(0),

--- a/src/faucet/ReactiveFaucetL1.sol
+++ b/src/faucet/ReactiveFaucetL1.sol
@@ -9,11 +9,12 @@ contract ReactiveFaucetL1 {
     );
 
     address payable private owner;
-
     uint256 public max_payout;
+    uint256 public exchangeRate;
 
-    constructor(uint256 _max_payout) {
+    constructor(uint256 _max_payout, uint256 _exchangeRate) {
         max_payout = _max_payout;
+        exchangeRate = _exchangeRate;
         owner = payable(msg.sender);
     }
 
@@ -39,8 +40,13 @@ contract ReactiveFaucetL1 {
         max_payout = _max_payout;
     }
 
+    function setExchangeRate(uint256 _exchangeRate) external onlyOwner {
+        exchangeRate = _exchangeRate;
+    }
+
     function _request(address receiver, uint256 value) internal {
-        uint256 amount = value > max_payout ? max_payout : value;
+        uint256 adjustedAmount = (value * exchangeRate) / 1e18;
+        uint256 amount = adjustedAmount > max_payout ? max_payout : adjustedAmount;
         require(amount > 0, 'Just no');
         emit PaymentRequest(receiver, amount);
     }

--- a/src/faucet/ReactiveFaucetL1.sol
+++ b/src/faucet/ReactiveFaucetL1.sol
@@ -9,12 +9,11 @@ contract ReactiveFaucetL1 {
     );
 
     address payable private owner;
-    uint256 public max_payout;
-    uint256 public exchangeRate;
 
-    constructor(uint256 _max_payout, uint256 _exchangeRate) {
+    uint256 public max_payout;
+
+    constructor(uint256 _max_payout) {
         max_payout = _max_payout;
-        exchangeRate = _exchangeRate;
         owner = payable(msg.sender);
     }
 
@@ -40,13 +39,8 @@ contract ReactiveFaucetL1 {
         max_payout = _max_payout;
     }
 
-    function setExchangeRate(uint256 _exchangeRate) external onlyOwner {
-        exchangeRate = _exchangeRate;
-    }
-
     function _request(address receiver, uint256 value) internal {
-        uint256 adjustedAmount = (value * exchangeRate) / 1e18;
-        uint256 amount = adjustedAmount > max_payout ? max_payout : adjustedAmount;
+        uint256 amount = value > max_payout ? max_payout : value;
         require(amount > 0, 'Just no');
         emit PaymentRequest(receiver, amount);
     }


### PR DESCRIPTION
**ReativeFaucet:**

- added exch rate to the constructor
- added `setExchangeRate()` to be able to change the rate on-the-go
- removed function `getPausableSubscriptions()` as it's part of (import '../../lib/reactive-lib/src/abstract-base/AbstractPausableReactive.sol';)
- modified the logic of `react()`

**ReactiveFaucetL1:**
- aligned the contract with accordance to `ReactiveFaucet`

**Guidance required:** are edits in `ReactiveFaucetL1` a must?